### PR TITLE
Correct for unequal class weights inclass fractions of leaf populations

### DIFF
--- a/dtreeviz/shadow.py
+++ b/dtreeviz/shadow.py
@@ -47,7 +47,6 @@ class ShadowDecTree:
         self.feature_names = feature_names
         self.class_names = class_names
         self.class_weight = tree_model.class_weight
-        self.class_weights = compute_class_weight(tree_model.class_weight, np.unique(y_train), y_train)
 
         if getattr(tree_model, 'tree_') is None: # make sure model is fit
             tree_model.fit(X_train, y_train)
@@ -68,6 +67,7 @@ class ShadowDecTree:
         self.y_train = y_train
         self.unique_target_values = np.unique(y_train)
         self.node_to_samples = ShadowDecTree.node_samples(tree_model, X_train)
+        self.class_weights = compute_class_weight(tree_model.class_weight, self.unique_target_values, self.y_train)
 
         tree = tree_model.tree_
         children_left = tree.children_left

--- a/dtreeviz/shadow.py
+++ b/dtreeviz/shadow.py
@@ -11,6 +11,7 @@ import string
 import re
 from typing import Mapping, List, Tuple
 from numbers import Number
+from sklearn.utils import compute_class_weight
 
 
 class ShadowDecTree:
@@ -45,6 +46,8 @@ class ShadowDecTree:
         self.tree_model = tree_model
         self.feature_names = feature_names
         self.class_names = class_names
+        self.class_weight = tree_model.class_weight
+        self.class_weights = compute_class_weight(tree_model.class_weight, np.unique(y_train), y_train)
 
         if getattr(tree_model, 'tree_') is None: # make sure model is fit
             tree_model.fit(X_train, y_train)
@@ -271,7 +274,10 @@ class ShadowDecTreeNode:
         associated with each class.
         """
         if self.isclassifier():
-            return np.array(self.shadow_tree.tree_model.tree_.value[self.id][0], dtype=int)
+            if self.shadow_tree.class_weight is None:
+                return np.array(self.shadow_tree.tree_model.tree_.value[self.id][0], dtype=int)
+            else:
+                return (np.round(self.shadow_tree.tree_model.tree_.value[self.id][0])/self.shadow_tree.class_weights).astype(int)
         return None
 
     def __str__(self):

--- a/dtreeviz/shadow.py
+++ b/dtreeviz/shadow.py
@@ -277,7 +277,7 @@ class ShadowDecTreeNode:
             if self.shadow_tree.class_weight is None:
                 return np.array(self.shadow_tree.tree_model.tree_.value[self.id][0], dtype=int)
             else:
-                return (np.round(self.shadow_tree.tree_model.tree_.value[self.id][0])/self.shadow_tree.class_weights).astype(int)
+                return np.round(self.shadow_tree.tree_model.tree_.value[self.id][0]/self.shadow_tree.class_weights).astype(int)
         return None
 
     def __str__(self):


### PR DESCRIPTION
In the current implementation, class weights -- e.g. DecisionTreeClassifier(class_weight='balanced') -- are not corrected for when plotting the pie charts with the class fractions of the final leaf populations. This pull requests fixes this by 
* tracking the decision tree class weights in the shadow tree
* dividing by the class weights before plotting (if class weights is other than None)