### PR TITLE
Added colorbar to rtreeviz_bivar_heatmap

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -199,7 +199,7 @@ def rtreeviz_bivar_heatmap(ax, X_train, y_train, max_depth, feature_names,
     x, y, z = X_train[:,0], X_train[:,1], y_train
     
     cmap = matplotlib.colors.ListedColormap(color_map)
-    pts = ax.scatter(x, y, marker='o', alpha=.95, edgecolor=GREY, lw=.3, cmap=cmap, c=z, vmin=z.min(), vmax=z.max())
+    pts = ax.scatter(x, y, marker='o', alpha=.95, edgecolor=GREY, lw=.3, cmap=cmap, c=z)
     plt.colorbar(pts)
     
     ax.set_xlabel(f"{feature_names[0]}", fontsize=fontsize, fontname=fontname, color=GREY)

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -197,8 +197,11 @@ def rtreeviz_bivar_heatmap(ax, X_train, y_train, max_depth, feature_names,
 
     colors = [color_map[int(((y-y_lim[0])/y_range)*(n_colors_in_map-1))] for y in y_train]
     x, y, z = X_train[:,0], X_train[:,1], y_train
-    ax.scatter(x, y, marker='o', alpha=.95, c=colors, edgecolor=GREY, lw=.3)
-
+    
+    cmap = matplotlib.colors.ListedColormap(color_map)
+    pts = ax.scatter(x, y, marker='o', alpha=.95, edgecolor=GREY, lw=.3, cmap=cmap, c=z, vmin=z.min(), vmax=z.max())
+    plt.colorbar(pts)
+    
     ax.set_xlabel(f"{feature_names[0]}", fontsize=fontsize, fontname=fontname, color=GREY)
     ax.set_ylabel(f"{feature_names[1]}", fontsize=fontsize, fontname=fontname, color=GREY)
 


### PR DESCRIPTION
In bivariate feature-target space plots it is easy to understand what are the targeted values because they are represented as a dimension of the plot:
![image](https://user-images.githubusercontent.com/16240134/58536192-11116e80-81f0-11e9-8cac-e466fcdd24e3.png)

But in bivariate feature-target space heatmap, there is no indication at all of the values represented by the colors: 
![image](https://user-images.githubusercontent.com/16240134/58536232-30100080-81f0-11e9-994c-60615a81f566.png)

This PR adds a colorbar to the heatmap so that it is easier to understand how colors are related to actual values:
![image](https://user-images.githubusercontent.com/16240134/58536280-52a21980-81f0-11e9-9370-5d0626f42a95.png)