### PR TITLE
fix: indexing wrt class_names & relevant issues

### DIFF
--- a/dtreeviz/shadow.py
+++ b/dtreeviz/shadow.py
@@ -120,8 +120,8 @@ class ShadowDecTree:
             X, y = X_feature[node.samples()], y_train[node.samples()]
             X_hist = [X[y == cl] for cl in class_values]
             height_of_bins = np.zeros(nbins)
-            for cl in class_values:
-                hist, foo = np.histogram(X_hist[cl], bins=bins, range=overall_feature_range)
+            for i,_ in enumerate(class_values):
+                hist, foo = np.histogram(X_hist[i], bins=bins, range=overall_feature_range)
                 # print(f"class {cl}: goal_n={len(bins):2d} n={len(hist):2d} {hist}")
                 height_of_bins += hist
             node_heights[node.id] = np.max(height_of_bins)

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -1121,7 +1121,7 @@ def draw_legend(shadow_tree, target_name, filename, colors=None):
     boxes = []
     for i, c in enumerate(class_values):
         box = patches.Rectangle((0, 0), 20, 10, linewidth=.4, edgecolor=colors['rect_edge'],
-                                facecolor=color_map[c], label=class_names[c])
+                                facecolor=color_map[c], label=class_names[i])
         boxes.append(box)
 
     fig, ax = plt.subplots(1, 1, figsize=(1,1))


### PR DESCRIPTION
Thx for your cool work wrt `dtreeviz` package!

But, I've recently encountered with some issues, for example:
* if you have not ordered class_names (suppose not from zero):
np.unique[y] => [1, 2, 3]
* you get class names (if you provide them as sequence):
{0: 1, 1: 2, 2: 3}
and...
```python
    for i, c in enumerate(class_values):
        print(i, c)
        box = patches.Rectangle((0, 0), 20, 10, linewidth=.4, edgecolor=GREY,
                                facecolor=colors[c], label=class_names[c])
```
This code cause the error
* if we manually provide dict via existing list:
{val: idx for idx, val in enumerate(class_names)}
We also fall in error there:
```python
X_hist = [X[y == cl] for cl in class_values]
for cl in enumerate(class_values):
    hist, foo = np.histogram(X_hist[cl], bins=bins, range=overall_feature_range)
```