### PR TITLE
fix : the right arrows in path to test data are not highlighted

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -809,7 +809,7 @@ def dtreeviz(tree_model: (tree.DecisionTreeRegressor, tree.DecisionTreeClassifie
             lcolor = colors['highlight']
             lpw = "1.2"
         if node.right.id in highlight_path:
-            lcolor = colors['highlight']
+            rcolor = colors['highlight']
             rpw = "1.2"
         edges.append( f'{nname} -> {left_node_name} [penwidth={lpw} color="{lcolor}" label=<{llabel}>]' )
         edges.append( f'{nname} -> {right_node_name} [penwidth={rpw} color="{rcolor}" label=<{rlabel}>]' )


### PR DESCRIPTION
In the current implementation, the right arrows in path to test data are not highlighted. For example, 

<div align="center">
<img width="500" alt="before" src="https://user-images.githubusercontent.com/30771923/67158127-fd1d0380-f36e-11e9-917a-7dc69bac9894.png">
</div>

This pull request fixes this by modifying rcolor in dtreeviz/tree.py
After modifying,

<div align="center">
<img width="500" alt="after" src="https://user-images.githubusercontent.com/30771923/67158286-2dfe3800-f371-11e9-8040-1cb7b1cc25c2.png">
</div>