### PR TITLE
Fix scale_SVG

### DIFF
--- a/dtreeviz/utils.py
+++ b/dtreeviz/utils.py
@@ -89,7 +89,7 @@ def scale_SVG(svg:str, scale:float) -> str:
     Convert:
 
     <svg ... height="382pt" viewBox="0.00 0.00 344.00 382.00" width="344pt">
-    <g class="graph" id="graph0" transform="scale(1 1) rotate(0) translate(4 378)">
+    <g class="graph" id="graph0" transform="scale(1.0 1.0) rotate(0) translate(4 378)">
 
     To:
 
@@ -109,7 +109,7 @@ def scale_SVG(svg:str, scale:float) -> str:
     ns = {"svg": "http://www.w3.org/2000/svg"}
     graph = root.find(".//svg:g", ns) # get first node, which is graph
     transform = graph.attrib['transform']
-    transform = transform.replace('scale(1 1)', f'scale({scale} {scale})')
+    transform = transform.replace('scale(1.0 1.0)', f'scale({scale} {scale})')
     graph.set("transform", transform)
 
     ET.register_namespace('', "http://www.w3.org/2000/svg")


### PR DESCRIPTION
This function replaces the scale of the SVG with a given input. SVG file uses float numbers, but this function searched for integer numbers, which did not exist.