### PR TITLE
Fix: xgb_decision_tree `shouldGoLeftAtSplit` -- massive-speed-up

### DIFF
--- a/dtreeviz/models/xgb_decision_tree.py
+++ b/dtreeviz/models/xgb_decision_tree.py
@@ -159,7 +159,7 @@ class ShadowXGBDTree(ShadowDecTree):
         return self.booster.trees_to_dataframe().query(f"Tree == {self.tree_index}")
 
     def _get_column_value(self, column_name):
-        return self._get_tree_dataframe()[column_name].to_numpy()
+        return self.tree_to_dataframe[column_name].to_numpy()
 
     def _get_nodes_values(self, column_name):
         nodes = self._get_column_value(self.NODE_COLUMN)


### PR DESCRIPTION
I noticed that for my xgboost model `dtreeviz.interpretation.explain_prediction_plain_english` is meticulously slow. After some investigation I figured out that `shadow_tree.predict_path` is taking the main chunk of compute time. Eventually it all boils down to one [line](https://github.com/parrt/dtreeviz/blob/e2cb111c55b04f234d57a9c1794e12a998dfcaf6/dtreeviz/models/xgb_decision_tree.py#L162)
```python
def _get_column_value(self, column_name):
    return self._get_tree_dataframe()[column_name].to_numpy()
```

which extracts the full tree dataset on every call. I am not sure if this is necessary, as it's already being done once on `__init__` and then stored in `self.tree_to_dataframe`. But even if that dataframe is being mutated down the line, maybe we could keep a copy just for `_get_column_value`. As changing `self._get_tree_dataframe()` to `self.tree_to_dataframe` leads to an insane speedup. 

On my use-case the runtime is reduced is from minutes to seconds -- I generate multiple explanations for the same model.
