### PR TITLE
added support for up to 40 colors

### DIFF
--- a/dtreeviz/colors.py
+++ b/dtreeviz/colors.py
@@ -1,3 +1,6 @@
+import matplotlib
+import numpy as np
+
 YELLOW = '#fefecd'
 GREEN = '#cfe2d4'
 DARKBLUE = '#313695'
@@ -24,7 +27,57 @@ color_blind_friendly_colors = [
     ['#FEFEBB', '#edf8b1', '#c7e9b4', '#7fcdbb', '#1d91c0', '#225ea8', '#fdae61', '#f46d43'],  # 8
     ['#FEFEBB', '#c7e9b4', '#41b6c4', '#74add1', BLUE, DARKBLUE, LIGHTORANGE, '#fdae61', '#f46d43'],  # 9
     ['#FEFEBB', '#c7e9b4', '#41b6c4', '#74add1', BLUE, DARKBLUE, LIGHTORANGE, '#fdae61', '#f46d43', '#d73027']  # 10
+
 ]
+
+def get_hex_colors(n_classes,cmap_name = "RdYlBu"):
+    """will generate a list of lists that contain n discrete hex colors
+     from a given matplotlib colormap based on the number of classes in 
+     a given classifier model as determined in trees.py. Defaults to the 
+     "RdYlBu" colormap. 
+
+    Args:
+        n_classes (int): the number of classes in a classifier model as determined 
+        by trees.py
+        cmap_name (str, optional): any valid matplotlib colormap. Defaults to "RdYlBu".
+
+    Returns:
+        list: a list of lists where each inner list item contains n discrete hex colors.
+        Ex:
+        get_hex_colors(10)
+
+        [
+            None, # 0 classes
+            None, # 1 class
+            ['#a50026ff', '#313695ff'], # 2 classes
+            ['#a50026ff', '#ffffbfff', '#313695ff'], # 3 classes
+            ['#a50026ff', '#fdbf71ff', '#bde2eeff', '#313695ff'], # 4 classes
+            ['#a50026ff', '#f88d52ff', '#ffffbfff', '#90c3ddff', '#313695ff'], # 5 classes
+            ['#a50026ff', '#f46d43ff', '#fee090ff', '#e0f3f8ff', '#74add1ff', '#313695ff'], # 6 classes
+            ['#a50026ff', '#ea593aff', '#fdbf71ff', '#ffffbfff', '#bde2eeff', '#649ac7ff', '#313695ff'], # 7 classes
+            ['#a50026ff', '#e34a33ff', '#fca55dff', '#fee99dff', '#e9f6e8ff', '#a3d3e6ff', '#598dc0ff', '#313695ff'], # 8 classes
+            ['#a50026ff', '#de3f2eff', '#f88d52ff', '#fed384ff', '#ffffbfff', '#d3ecf4ff', '#90c3ddff', '#5183bbff', '#313695ff'], # 9 classes
+            ['#a50026ff', '#da372aff', '#f67b4aff', '#fdbf71ff', '#feeea5ff', '#eef8dfff', '#bde2eeff', '#80b7d6ff', '#4a7bb7ff', '#313695ff'], # 10 classes
+
+        ]
+    """
+ 
+    
+    hex_colors = []
+    for i in range(2, n_classes + 1):
+        cmap = matplotlib.cm.get_cmap(cmap_name, i)
+        hex_colors.append(
+            [
+                matplotlib.colors.to_hex(rgb, keep_alpha=True)
+                for rgb in cmap(np.arange(0, cmap.N))
+            ]
+        )
+
+    hex_colors.insert(0, None)
+    hex_colors.insert(0, None)
+    
+    return hex_colors
+
 
 COLORS = {'scatter_edge': GREY,
           'scatter_marker': BLUE,

--- a/dtreeviz/colors.py
+++ b/dtreeviz/colors.py
@@ -29,6 +29,10 @@ color_blind_friendly_colors = [
     ['#FEFEBB', '#c7e9b4', '#41b6c4', '#74add1', BLUE, DARKBLUE, LIGHTORANGE, '#fdae61', '#f46d43', '#d73027']  # 10
 
 ]
+def get_colorblind_friendly_colors():
+    colors  = color_blind_friendly_colors
+
+    return colors
 
 def get_hex_colors(n_classes,cmap_name = "RdYlBu"):
     """will generate a list of lists that contain n discrete hex colors
@@ -64,7 +68,7 @@ def get_hex_colors(n_classes,cmap_name = "RdYlBu"):
  
     
     hex_colors = []
-    for i in range(2, n_classes + 1):
+    for i in range(2, n_classes):
         cmap = matplotlib.cm.get_cmap(cmap_name, i)
         hex_colors.append(
             [

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -17,15 +17,26 @@ from numbers import Number
 
 from dtreeviz import interpretation as prediction_path
 from dtreeviz.colors import adjust_colors
+from dtreeviz.colors import get_hex_colors
+
 from dtreeviz.models.shadow_decision_tree import ShadowDecTree
 from dtreeviz.models.shadow_decision_tree import ShadowDecTreeNode
 from dtreeviz.utils import inline_svg_images, myround, scale_SVG
 
+
 # How many bins should we have based upon number of classes
-NUM_BINS = [0, 0, 10, 9, 8, 6, 6, 6, 5, 5, 5]
+NUM_BINS = [
+    0, 0, 10, 9, 8, 6,
+    6, 6, 5, 5, 5, 5, 
+    5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 5,
+    5, 5, 5, 5, 5, 
+    ] # support for 40 classes
 
 
-# 0, 1, 2,  3, 4, 5, 6, 7, 8, 9, 10
+
 
 
 class DTreeViz:
@@ -512,6 +523,7 @@ def dtreeviz(tree_model,
              title: str = None,
              title_fontsize: int = 14,
              colors: dict = None,
+             cmap: str = "RdYlBu",
              scale=1.0
              ) \
         -> DTreeViz:
@@ -766,6 +778,10 @@ def dtreeviz(tree_model,
         highlight_path = [n.id for n in path]
 
     n_classes = shadow_tree.nclasses()
+
+    # call the get_hex_colors function for up to 40 classes
+    colors['classes'] = get_hex_colors(n_classes,cmap) 
+
     color_values = colors['classes'][n_classes]
 
     # Fix the mapping from target value to color for entire tree

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -16,9 +16,9 @@ from typing import Mapping, List, Tuple
 from numbers import Number
 
 from dtreeviz import interpretation as prediction_path
+from dtreeviz.colors import get_colorblind_friendly_colors
 from dtreeviz.colors import adjust_colors
 from dtreeviz.colors import get_hex_colors
-
 from dtreeviz.models.shadow_decision_tree import ShadowDecTree
 from dtreeviz.models.shadow_decision_tree import ShadowDecTreeNode
 from dtreeviz.utils import inline_svg_images, myround, scale_SVG
@@ -782,10 +782,12 @@ def dtreeviz(tree_model,
     # only generate custom colors if n_classes > 10
     # otherwise keep the original colorblind friendly colors
     if n_classes > 10:
-
         # call the get_hex_colors function for up to 40 classes
-        colors['classes'] = get_hex_colors(n_classes,cmap) 
+        colors['classes'] = get_hex_colors(n_classes+1,cmap) 
 
+    else:
+        colors['classes'] = get_colorblind_friendly_colors()
+    
     color_values = colors['classes'][n_classes]
 
     # Fix the mapping from target value to color for entire tree

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -779,8 +779,12 @@ def dtreeviz(tree_model,
 
     n_classes = shadow_tree.nclasses()
 
-    # call the get_hex_colors function for up to 40 classes
-    colors['classes'] = get_hex_colors(n_classes,cmap) 
+    # only generate custom colors if n_classes > 10
+    # otherwise keep the original colorblind friendly colors
+    if n_classes > 10:
+
+        # call the get_hex_colors function for up to 40 classes
+        colors['classes'] = get_hex_colors(n_classes,cmap) 
 
     color_values = colors['classes'][n_classes]
 


### PR DESCRIPTION
by adding a helper function in ```colors.py```, we can now create as many discrete colors from any valid matplotlib colormap as a classifier model has classes. The limit on this is 40 based on the length of ```NUM_BINS``` in ```trees.py``` which should take care of most classification problems. 

When calling the ```dtreeviz``` function the argument ```cmap``` can now be specified, otherwise defaults to the ```RdYlBu``` from matplotlib:

```python
viz = dtreeviz(
    rf.estimators_[tree_number],
    X,
    y,
    target_name="target_class",
    feature_names=features_list,
    class_names=class_names,
    cmap = 'viridis'

)
viz.view()
```