### PR TITLE
Corrected flow of control of color classes

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -779,14 +779,11 @@ def dtreeviz(tree_model,
 
     n_classes = shadow_tree.nclasses()
 
-    # only generate custom colors if n_classes > 10
-    # otherwise keep the original colorblind friendly colors
-    if n_classes > 10:
+    # Only generate custom colors if the current class color lists,
+    # whether user-supplied or the default ones, are not enough.
+    if n_classes+1 > len(colors['classes']):
         # call the get_hex_colors function for up to 40 classes
         colors['classes'] = get_hex_colors(n_classes+1,cmap) 
-
-    else:
-        colors['classes'] = get_colorblind_friendly_colors()
     
     color_values = colors['classes'][n_classes]
 


### PR DESCRIPTION
Corrected a bug in the flow of control of dtreeviz. Now a potential user-supplied color dictionary would not have the content of the 'classes' key overwritten.