### PR TITLE
Small cleanup of API

### DIFF
--- a/dtreeviz/classifiers.py
+++ b/dtreeviz/classifiers.py
@@ -134,7 +134,7 @@ def decision_boundaries_bivar(model, X:np.ndarray, y:np.ndarray,
                  fontsize=9, fontname="Arial",
                  dot_w=25, colors:dict=None,
                  ranges=None,
-                 figsize=(5, 3.5),
+                 figsize=None,
                  ax=None) -> None:
     """
     See comment and parameter descriptions for decision_boundaries() above.
@@ -148,7 +148,10 @@ def decision_boundaries_bivar(model, X:np.ndarray, y:np.ndarray,
         raise ValueError(f"Expecting 2D data not {X.shape}")
 
     if ax is None:
-        fig, ax = plt.subplots(1, 1, figsize=figsize)
+        if figsize:
+            fig, ax = plt.subplots(figsize=figsize)
+        else:
+            fig, ax = plt.subplots()
 
     # Created grid over the range of x1 and x2 variables, get probabilities, predictions
     grid_points, grid_proba, grid_pred_as_matrix, w, x_, class_X, class_values = \
@@ -383,13 +386,16 @@ def decision_boundaries_univar(model, x: np.ndarray, y: np.ndarray,
                   yshift=.09,
                   sigma=.09,
                   colors: dict = None,
-                  figsize=(5, 1.2),
+                  figsize=None,
                   ax=None) -> None:
     """
     See comment and parameter descriptions for decision_boundaries() above.
     """
     if ax is None:
-        fig, ax = plt.subplots(1, 1, figsize=figsize)
+        if figsize:
+            fig, ax = plt.subplots(figsize=figsize)
+        else:
+            fig, ax = plt.subplots()
 
     if isinstance(x, pd.Series):
         x = x.values

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -1457,7 +1457,6 @@ class DTreeViz:
              title: str = None,
              title_fontsize: int = 10,
              colors: dict = None,
-             cmap: str = "RdYlBu",
              scale=1.0
              ) \
             -> DTreeVizRender:

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -1314,7 +1314,10 @@ class DTreeViz:
         if display_type == "plot":
             colors = adjust_colors(colors)
             if ax is None:
-                fig, ax = plt.subplots(figsize=figsize)
+                if figsize:
+                    fig, ax = plt.subplots(figsize=figsize)
+                else:
+                    fig, ax = plt.subplots()
             ax.spines['top'].set_visible(False)
             ax.spines['right'].set_visible(False)
             ax.spines['left'].set_linewidth(.3)
@@ -1336,7 +1339,10 @@ class DTreeViz:
         elif display_type == "hist":
             colors = adjust_colors(colors)
             if ax is None:
-             fig, ax = plt.subplots(figsize=figsize)
+                if figsize:
+                    fig, ax = plt.subplots(figsize=figsize)
+                else:
+                    fig, ax = plt.subplots()
             ax.spines['top'].set_visible(False)
             ax.spines['right'].set_visible(False)
             ax.spines['left'].set_linewidth(.3)
@@ -1398,7 +1404,10 @@ class DTreeViz:
             colors_classes = colors['classes'][self.shadow_tree.nclasses()]
 
             if ax is None:
-                fig, ax = plt.subplots(figsize=figsize)
+                if figsize:
+                    fig, ax = plt.subplots(figsize=figsize)
+                else:
+                    fig, ax = plt.subplots()
             ax.spines['top'].set_visible(False)
             ax.spines['right'].set_visible(False)
             ax.spines['left'].set_linewidth(.3)
@@ -1921,7 +1930,10 @@ class DTreeViz:
         if display_type == "plot":
             colors = adjust_colors(colors)
             if ax is None:
-                fig, ax = plt.subplots(figsize=figsize)
+                if figsize:
+                    fig, ax = plt.subplots(figsize=figsize)
+                else:
+                    fig, ax = plt.subplots()
             ax.spines['top'].set_visible(False)
             ax.spines['right'].set_visible(False)
             ax.spines['left'].set_linewidth(.3)
@@ -1944,7 +1956,10 @@ class DTreeViz:
         elif display_type == "hist":
             colors = adjust_colors(colors)
             if ax is None:
-                fig, ax = plt.subplots(figsize=figsize)
+                if figsize:
+                    fig, ax = plt.subplots(figsize=figsize)
+                else:
+                    fig, ax = plt.subplots()
             ax.spines['top'].set_visible(False)
             ax.spines['right'].set_visible(False)
             ax.spines['left'].set_linewidth(.3)


### PR DESCRIPTION
don't assume a figsize; let it default to matplotlib size unless they set figsize as arg (or pass in an ax).