### PR TITLE
Add option to plot classifier leaves as horizontal bars

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -1356,7 +1356,7 @@ def _draw_barh_chart(counts, size, colors, filename, label=None, fontname="Arial
             colors = [colors[i]]
 
     tweak = size * .01
-    fig, ax = plt.subplots(1, 1, figsize=(size, 0.3))
+    fig, ax = plt.subplots(1, 1, figsize=(size, 0.2))
 
     data_cum = 0
     for i in range(len(counts)):


### PR DESCRIPTION
Added `leaf_plot_type` parameter. Default is `pie` which replicates prior plots, but now includes a `barh` option!

![dtreeviz](https://user-images.githubusercontent.com/4729931/209851578-74408af2-9bf7-4d02-b56d-e0d40ea62ae7.png)
