### PR TITLE
Add matplotlib default colors as mpl_colors

### DIFF
--- a/dtreeviz/colors.py
+++ b/dtreeviz/colors.py
@@ -31,6 +31,17 @@ color_blind_friendly_colors = [
 ]
 
 
+mpl_colors = [
+    None,  # 0 classes
+    None,  # 1 class
+]
+for n_classes in range(2, 11):
+    class_colors = []
+    for i in range(0, n_classes):
+        class_colors.append(f'C{i}')
+    mpl_colors.append(class_colors)
+
+
 def get_hex_colors(n_classes, cmap_name="RdYlBu"):
     """
     Will generate a list of lists that contain n discrete hex colors


### PR DESCRIPTION
Defined a set of matplotlib default colors, `C0, C1, C2`, ..., for convenience. See `mpl_colors`, which mirrors `color_blind_friendly_colors`.

We can leave the default colors as `color_blind_friendly_colors`, but I think it is useful to set this up in advance for users, so they don't need to themselves.

![dtreeviz](https://user-images.githubusercontent.com/4729931/209853299-35d949e7-8e9a-466f-bfb9-b796da93b814.png)
