### PR TITLE
Fix Python Warnings

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -117,7 +117,7 @@ class DTreeVizAPI:
                 rect.set_edgecolor(colors['rect_edge'])
             ax.set_xlabel("leaf ids", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
             ax.set_ylabel("samples count", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
-            ax.grid(b=grid)
+            ax.grid(visible=grid)
         elif display_type == "text":
             for leaf, samples in zip(leaf_id, leaf_sizes):
                 print(f"leaf {leaf} has {samples} samples")
@@ -138,7 +138,7 @@ class DTreeVizAPI:
                 rect.set_edgecolor(colors['rect_edge'])
             ax.set_xlabel("leaf sample", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
             ax.set_ylabel("leaf count", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
-            ax.grid(b=grid)
+            ax.grid(visible=grid)
 
     def ctree_leaf_distributions(self,
                                  display_type: str = "plot",
@@ -212,7 +212,7 @@ class DTreeVizAPI:
 
             ax.set_xlabel("leaf ids", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
             ax.set_ylabel("samples by class", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
-            ax.grid(grid)
+            ax.grid(visible=grid)
             ax.legend([bar_container0, bar_container1],
                       [f'class {self.shadow_tree.classes()[0]}', f'class {self.shadow_tree.classes()[1]}'])
         elif display_type == "text":
@@ -728,7 +728,7 @@ class DTreeVizAPI:
             ax.set_xlabel("leaf ids", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
             ax.set_ylabel(f"{self.shadow_tree.criterion()}", fontsize=fontsize, fontname=fontname,
                           color=colors['axis_label'])
-            ax.grid(b=grid)
+            ax.grid(visible=grid)
         elif display_type == "text":
             for leaf, criteria in zip(leaf_id, leaf_criteria):
                 print(f"leaf {leaf} has {criteria} {self.shadow_tree.criterion()}")
@@ -750,7 +750,7 @@ class DTreeVizAPI:
             ax.set_xlabel(f"{self.shadow_tree.criterion()}", fontsize=fontsize, fontname=fontname,
                           color=colors['axis_label'])
             ax.set_ylabel("leaf count", fontsize=fontsize, fontname=fontname, color=colors['axis_label'])
-            ax.grid(b=grid)
+            ax.grid(visible=grid)
 
     def node_stats(self, node_id: int) -> pd.DataFrame:
         """Generate stats (count, mean, std, etc) based on data samples from a specified node.
@@ -891,7 +891,7 @@ class DTreeVizAPI:
         ax.set_xlabel(self.shadow_tree.target_name.lower(), fontsize=label_fontsize, fontname=fontname,
                       color=colors['axis_label'])
         ax.set_ylabel("leaf", fontsize=label_fontsize, fontname=fontname, color=colors['axis_label'])
-        ax.grid(b=grid)
+        ax.grid(visible=grid)
 
         if show_leaf_labels:
             for i in range(len(y_labels)):

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -1624,7 +1624,7 @@ def _rtreeviz_bivar_heatmap(shadow_tree, fontsize=10, ticks_fontsize=12, fontnam
         y = bbox[1]
         w = bbox[2] - bbox[0]
         h = bbox[3] - bbox[1]
-        rect = patches.Rectangle((x, y), w, h, 0, linewidth=.3, alpha=colors['tesselation_alpha'],
+        rect = patches.Rectangle((x, y), w, h, angle=0, linewidth=.3, alpha=colors['tesselation_alpha'],
                                  edgecolor=colors['edge'], facecolor=color)
         ax.add_patch(rect)
 

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -1499,7 +1499,7 @@ def _ctreeviz_bivar(shadow_tree, fontsize=10, fontname="Arial", show={'title', '
             y = bbox[1]
             w = bbox[2] - bbox[0]
             h = bbox[3] - bbox[1]
-            rect = patches.Rectangle((x, y), w, h, 0, linewidth=.3, alpha=colors['tesselation_alpha'],
+            rect = patches.Rectangle((x, y), w, h, angle=0, linewidth=.3, alpha=colors['tesselation_alpha'],
                                      edgecolor=colors['rect_edge'], facecolor=color_map[node.prediction()])
             ax.add_patch(rect)
 

--- a/dtreeviz/utils.py
+++ b/dtreeviz/utils.py
@@ -119,7 +119,7 @@ def scale_SVG(svg:str, scale:float) -> str:
     ns = {"svg": "http://www.w3.org/2000/svg"}
     graph = root.find(".//svg:g", ns) # get first node, which is graph
     transform = graph.attrib['transform']
-    pattern = re.compile(f"scale\([0-9.]+\ [0-9.]+\)")
+    pattern = re.compile(r"scale\([0-9.]+\ [0-9.]+\)")
     scale_str = pattern.search(transform).group()
     transform = transform.replace(scale_str, f'scale({scale} {scale})')
     graph.set("transform", transform)


### PR DESCRIPTION
- Fixed `angle` matplotlib warning in `patches.Rectangle()`.
- Fixed python text warning in `utils.py`: `pattern = re.compile(r"scale\([0-9.]+\ [0-9.]+\)")`.
- Updated `ax.grid(b=grid)` to new `ax.grid(visible=grid)` syntax throughout.
