### PR TITLE
Fix digraph hard coding

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -303,7 +303,7 @@ class DTreeVizAPI:
                     </tr>
                     </table>"""
             else:
-                html = f"""<font face="Helvetica" color="#444443" point-size="12">{name}@{split}</font>"""
+                html = f"""<font face="{fontname}" color="{colors["text"]}" point-size="12">{name}@{split}</font>"""
             if node.id in highlight_path:
                 gr_node = f'{node_name} [margin="0" shape=box penwidth=".5" color="{colors["highlight"]}" style="dashed" label=<{html}>]'
             else:

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -618,12 +618,12 @@ class DTreeVizAPI:
 
             if show_just_path:
                 if node.left.id in highlight_path:
-                    edges.append(f'{nname} -> {left_node_name} [penwidth={lpw} color="{lcolor}" label=<{llabel}>]')
+                    edges.append(f'{nname} -> {left_node_name} [penwidth={lpw} color="{lcolor}" label=<{llabel}> fontcolor="{colors["text"]}"]')
                 if node.right.id in highlight_path:
-                    edges.append(f'{nname} -> {right_node_name} [penwidth={rpw} color="{rcolor}" label=<{rlabel}>]')
+                    edges.append(f'{nname} -> {right_node_name} [penwidth={rpw} color="{rcolor}" label=<{rlabel}> fontcolor="{colors["text"]}"]')
             else:
-                edges.append(f'{nname} -> {left_node_name} [penwidth={lpw} color="{lcolor}" label=<{llabel}>]')
-                edges.append(f'{nname} -> {right_node_name} [penwidth={rpw} color="{rcolor}" label=<{rlabel}>]')
+                edges.append(f'{nname} -> {left_node_name} [penwidth={lpw} color="{lcolor}" label=<{llabel}> fontcolor="{colors["text"]}"]')
+                edges.append(f'{nname} -> {right_node_name} [penwidth={rpw} color="{rcolor}" label=<{rlabel}> fontcolor="{colors["text"]}"]')
                 edges.append(f"""
                     {{
                         rank=same;


### PR DESCRIPTION
- Used `colors["text"]` instead of hard coded `#444443` in digraph.
- Added missing fontcolor="{text_color}" to digraph edges. Now font color will match matplotlib text.
- Use  `fontname`  instead of hard coded Helvetica, in digraph.