### PR TITLE
Adapt utility function for `sklearn>=1.2.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,35 @@ from setuptools import setup, find_packages
 # $ python3 -m build
 # $ twine upload dist/dtreeviz-1.4.0.tar.gz dist/dtreeviz-1.4.0-py3-none-any.whl
 
+
+extra_xgboost = ['xgboost']
+extra_pyspark = ['pyspark']
+extra_lightgbm = ['lightgbm']
+extra_tensorflow = ['tensorflow_decision_forests']
+
+
 setup(
     name='dtreeviz',
     version='2.0.0',
     url='https://github.com/parrt/dtreeviz',
     license='MIT',
     packages=find_packages(),
-    install_requires=['graphviz>=0.9','pandas','numpy','scikit-learn',
-                        'matplotlib','colour', 'pytest'],
-    extras_require={'xgboost': ['xgboost'],
-                    'pyspark':['pyspark'],
-                    'lightgbm':['lightgbm'],
-                    'tensorflow_decision_forests':['tensorflow_decision_forests']},
+    install_requires=[
+        'graphviz>=0.9',
+        'pandas',
+        'numpy',
+        'scikit-learn',
+        'matplotlib',
+        'colour',
+        'pytest'
+    ],
+    extras_require={
+        'xgboost': extra_xgboost,
+        'pyspark': extra_pyspark,
+        'lightgbm': extra_lightgbm,
+        'tensorflow_decision_forests': extra_tensorflow,
+        'all': extra_xgboost + extra_pyspark + extra_lightgbm + extra_tensorflow,
+    },
     python_requires='>=3.6',
     author='Terence Parr, Tudor Lapusan, and Prince Grover',
     author_email='parrt@antlr.org',


### PR DESCRIPTION
This addresses #231 and refactors the `setup.py` a bit (open for discussion).

The feature extraction from sklearn-pipelines becomes much easier in version `1.2.0`. I added a if-condition (similar as suggested by @tlapusan) that checks whether the pipeline allows for this new feature. However, in the long run, maintaining compatibility to all the sklearn versions will increase the code complexity. I recommend to add a lower-bound on the `sklearn` version at some point.