### PR TITLE
Catvar support for tf-df

### DIFF
--- a/.idea/animl.iml
+++ b/.idea/animl.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.8" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.10" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/dtreeviz/utils.py
+++ b/dtreeviz/utils.py
@@ -397,13 +397,17 @@ def _draw_wedge(ax, x, node, color, is_class, h=None, height_range=None, bins=No
             _draw_tria(x, tip_y, tri_width, tri_height)
         else:
             # classification: categorical split, draw multiple wedges
-            for split_value in node.split():
-                # to display the wedge exactly in the middle of the vertical bar
-                for bin_index in range(len(bins) - 1):
-                    if bins[bin_index] <= split_value <= bins[bin_index + 1]:
-                        split_value = (bins[bin_index] + bins[bin_index + 1]) / 2
-                        break
-                _draw_tria(split_value, tip_y, tri_width, tri_height)
+            # @Tudor: here is a case where we might need to avoid drawing a triangle for now as it's categorical
+            # @Tudor: currently can be just one split; wondering why this is a loop.
+            split = node.split()
+            if not (isinstance(split, list) and isinstance(split[0], str)):
+                for split_value in split:
+                    # to display the wedge exactly in the middle of the vertical bar
+                    for bin_index in range(len(bins) - 1):
+                        if bins[bin_index] <= split_value <= bins[bin_index + 1]:
+                            split_value = (bins[bin_index] + bins[bin_index + 1]) / 2
+                            break
+                    _draw_tria(split_value, tip_y, tri_width, tri_height)
     else:
         # regression
         tri_height = y_range * .1

--- a/testing/tf_df_catvars.py
+++ b/testing/tf_df_catvars.py
@@ -1,0 +1,60 @@
+import tensorflow_decision_forests as tfdf
+import dtreeviz
+print(tfdf.__version__, dtreeviz.__version__ )
+
+import tensorflow as tf
+
+import os
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+import math
+
+from matplotlib import pyplot as plt
+
+def split_dataset(dataset, test_ratio=0.30, seed=1234):
+  """
+  Splits a panda dataframe in two, usually for train/test sets.
+  Using the same random seed ensures we get the same split so
+  that the description in this tutorial line up with generated images.
+  """
+  np.random.seed(seed)
+  test_indices = np.random.rand(len(dataset)) < test_ratio
+  return dataset[~test_indices], dataset[test_indices]
+
+df_penguins = pd.read_csv("penguins.csv")
+df_penguins = df_penguins.dropna()
+
+penguin_label = "species"
+penguin_features = list(df_penguins.columns)
+classes = df_penguins[penguin_label].unique().tolist()
+df_penguins[penguin_label] = df_penguins[penguin_label].map(classes.index)
+print(f"Label classes: {classes}")
+
+print(df_penguins.head(3))
+
+train_ds_pd, test_ds_pd = split_dataset(df_penguins)
+print(f"{len(train_ds_pd)} examples in training, {len(test_ds_pd)} examples for testing.")
+
+# Convert to tensorflow data sets
+train_ds = tfdf.keras.pd_dataframe_to_tf_dataset(train_ds_pd, label=penguin_label)
+test_ds = tfdf.keras.pd_dataframe_to_tf_dataset(test_ds_pd, label=penguin_label)
+
+cmodel = tfdf.keras.RandomForestModel(num_trees=20, verbose=0, random_seed=1234)
+cmodel.fit(x=train_ds)
+
+cmodel.compile(metrics=["accuracy"])
+print(cmodel.evaluate(test_ds, return_dict=True, verbose=0))
+
+which_tree = 3 # pick a tree from the forest to visualize
+
+viz_cmodel = dtreeviz.model(cmodel,
+                           tree_index=which_tree,
+                           X_train=train_ds_pd[penguin_features],
+                           y_train=train_ds_pd[penguin_label],
+                           feature_names=penguin_features,
+                           target_name=penguin_label,
+                           class_names=classes)
+
+viz_cmodel.view(leaftype='barh').show()
+#viz_cmodel.view().show() # crashes in pie chart. can't figure out why


### PR DESCRIPTION
@tlapusan please take a look at this branch that I started for you. If you run testing/tf_df_catvars.py, it should show you a classifier tree with bar chart for leaves not pie charts. Pie chart leaves crash at the moment.

I think in order to support string categorical variables we need to do the following:

1. Detect and convert strings to integers in `ShadowTensorflowTree.__init__` via `model()`; record the string to integer mapping for any categorical columns. I created and filled `self.catvar_maps`.
2. For now, we can simply not show a wedge for any catvar; this will probably work for both classifiers and regressors
3. There's no such thing as a "split value" for categoricals in the general case as it might be doing set membership in tensor flow trees. Per the previous bullet point, I have simply detected this and turned off split wedge display for strings.
4. We currently do our own walking of the tree in order to compute paths from the root to leaves, which means we do not properly handle categoricals for tensorflow. We need to ask the node for its set membership or better yet ask the underlying tf node to make the decision for us.
5. Labels on tree edges can only be less than or greater than; at the very least we should not turn that on beneath a categorical test for the moment.

Feel free to just cut and paste from this and put into your own branch. Not sure how to add you to this branch.

I put a ref to `@Tudor` add a place in the code where we are calling `node.splits()` that likely needs attention as well.

The good news is that this first example works who is very minimal changes. Pie charts crash and I'm sure it will crash if we try to Display a path from root to leaf. haha.  But, shouldn't be too bad.