### PR TITLE
Make leaves and nodes tmp files paths platform independent

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -560,7 +560,7 @@ class DTreeVizAPI:
             if fancy:
                 if self.shadow_tree.is_classifier():
                     _class_split_viz(node, X_train, y_train,
-                                     filename=os.path.join(tmp, f"/node{node.id}_{os.getpid()}.svg"),
+                                     filename=os.path.join(tmp, f"node{node.id}_{os.getpid()}.svg"),
                                      precision=precision,
                                      colors={**color_map, **colors},
                                      histtype=histtype,
@@ -596,7 +596,7 @@ class DTreeVizAPI:
                     continue
             if self.shadow_tree.is_classifier():
                 _class_leaf_viz(node, colors=color_values,
-                                filename=os.path.join(tmp, f"/leaf{node.id}_{os.getpid()}.svg"),
+                                filename=os.path.join(tmp, f"leaf{node.id}_{os.getpid()}.svg"),
                                 graph_colors=colors,
                                 fontname=fontname,
                                 leaftype=leaftype)
@@ -606,7 +606,7 @@ class DTreeVizAPI:
                 _regr_leaf_viz(node,
                                y_train,
                                target_name=self.shadow_tree.target_name,
-                               filename=os.path.join(tmp, f"/leaf{node.id}_{os.getpid()}.svg"),
+                               filename=os.path.join(tmp, f"leaf{node.id}_{os.getpid()}.svg"),
                                y_range=y_range,
                                precision=precision,
                                ticks_fontsize=ticks_fontsize,

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -391,7 +391,7 @@ class DTreeVizAPI:
             return f"""
                 <table border="0" cellspacing="0" cellpadding="0">
                     <tr>
-                        <td border="0" cellspacing="0" cellpadding="0"><img src="{tmp}/legend_{os.getpid()}.svg"/></td>
+                        <td border="0" cellspacing="0" cellpadding="0"><img src="{filepath}"/></td>
                     </tr>
                 </table>
                 """

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -527,7 +527,7 @@ class DTreeVizAPI:
             if np.max(class_values) >= n_classes:
                 raise ValueError(f"Target label values (for now) must be 0..{n_classes-1} for n={n_classes} labels")
             color_map = {v: color_values[i] for i, v in enumerate(class_values)}
-            _draw_legend(self.shadow_tree, self.shadow_tree.target_name, f"{tmp}/legend_{os.getpid()}.svg",
+            _draw_legend(self.shadow_tree, self.shadow_tree.target_name, os.path.join(tmp, f"legend_{os.getpid()}.svg"),
                          colors=colors,
                          fontname=fontname)
 
@@ -560,7 +560,7 @@ class DTreeVizAPI:
             if fancy:
                 if self.shadow_tree.is_classifier():
                     _class_split_viz(node, X_train, y_train,
-                                     filename=f"{tmp}/node{node.id}_{os.getpid()}.svg",
+                                     filename=os.path.join(tmp, f"/node{node.id}_{os.getpid()}.svg"),
                                      precision=precision,
                                      colors={**color_map, **colors},
                                      histtype=histtype,
@@ -572,7 +572,7 @@ class DTreeVizAPI:
                                      highlight_node=node.id in highlight_path)
                 else:
                     _regr_split_viz(node, X_train, y_train,
-                                    filename=f"{tmp}/node{node.id}_{os.getpid()}.svg",
+                                    filename=os.path.join(tmp, f"node{node.id}_{os.getpid()}.svg"),
                                     target_name=self.shadow_tree.target_name,
                                     y_range=y_range,
                                     X=x,
@@ -596,7 +596,7 @@ class DTreeVizAPI:
                     continue
             if self.shadow_tree.is_classifier():
                 _class_leaf_viz(node, colors=color_values,
-                                filename=f"{tmp}/leaf{node.id}_{os.getpid()}.svg",
+                                filename=os.path.join(tmp, f"/leaf{node.id}_{os.getpid()}.svg"),
                                 graph_colors=colors,
                                 fontname=fontname,
                                 leaftype=leaftype)
@@ -606,7 +606,7 @@ class DTreeVizAPI:
                 _regr_leaf_viz(node,
                                y_train,
                                target_name=self.shadow_tree.target_name,
-                               filename=f"{tmp}/leaf{node.id}_{os.getpid()}.svg",
+                               filename=os.path.join(tmp, f"/leaf{node.id}_{os.getpid()}.svg"),
                                y_range=y_range,
                                precision=precision,
                                ticks_fontsize=ticks_fontsize,

--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -338,11 +338,12 @@ class DTreeVizAPI:
 
         def split_node(name, node_name, split):
             if fancy:
+                filepath = os.path.join(tmp, f"node{node.id}_{os.getpid()}.svg")
                 labelgraph = node_label(node) if show_node_labels else ''
                 html = f"""<table border="0">
                     {labelgraph}
                     <tr>
-                            <td><img src="{tmp}/node{node.id}_{os.getpid()}.svg"/></td>
+                            <td><img src="{filepath}"/></td>
                     </tr>
                     </table>"""
             else:
@@ -356,10 +357,11 @@ class DTreeVizAPI:
         def regr_leaf_node(node, label_fontsize: int = 12):
             # always generate fancy regr leaves for now but shrink a bit for nonfancy.
             labelgraph = node_label(node) if show_node_labels else ''
+            filepath = os.path.join(tmp, f"leaf{node.id}_{os.getpid()}.svg")
             html = f"""<table border="0">
                 {labelgraph}
                 <tr>
-                        <td><img src="{tmp}/leaf{node.id}_{os.getpid()}.svg"/></td>
+                        <td><img src="{filepath}"/></td>
                 </tr>
                 </table>"""
             if node.id in highlight_path:
@@ -369,10 +371,11 @@ class DTreeVizAPI:
 
         def class_leaf_node(node, label_fontsize: int = 12):
             labelgraph = node_label(node) if show_node_labels else ''
+            filepath = os.path.join(tmp, f"leaf{node.id}_{os.getpid()}.svg")
             html = f"""<table border="0" CELLBORDER="0">
                 {labelgraph}
                 <tr>
-                        <td><img src="{tmp}/leaf{node.id}_{os.getpid()}.svg"/></td>
+                        <td><img src="{filepath}"/></td>
                 </tr>
                 </table>"""
             if node.id in highlight_path:
@@ -384,6 +387,7 @@ class DTreeVizAPI:
             return f'<tr><td CELLPADDING="0" CELLSPACING="0"><font face="{fontname}" color="{colors["node_label"]}" point-size="14"><i>Node {node.id}</i></font></td></tr>'
 
         def class_legend_html():
+            filepath = os.path.join(tmp, f"legend_{os.getpid()}.svg")
             return f"""
                 <table border="0" cellspacing="0" cellpadding="0">
                     <tr>


### PR DESCRIPTION
On windows graphviz throws cannot find file exceptions.
This is due to the hardcoded unix-style.

Example: C:\\Users\\username\\AppData\\Local\\Temp/leaf191_25772.svg