### PR TITLE
make leaves to be placeholders when not enough samples to fill them (…

### DIFF
--- a/dtreeviz/trees.py
+++ b/dtreeviz/trees.py
@@ -595,12 +595,12 @@ class DTreeVizAPI:
                 if node.level not in range(depth_range_to_display[0], depth_range_to_display[1] + 1):
                     continue
             if self.shadow_tree.is_classifier():
-                _class_leaf_viz(node, colors=color_values,
+                if _class_leaf_viz(node, colors=color_values,
                                 filename=f"{tmp}/leaf{node.id}_{os.getpid()}.svg",
                                 graph_colors=colors,
                                 fontname=fontname,
-                                leaftype=leaftype)
-                leaves.append(class_leaf_node(node))
+                                leaftype=leaftype):
+                    leaves.append(class_leaf_node(node))
             else:
                 # for now, always gen leaf
                 _regr_leaf_viz(node,
@@ -1255,13 +1255,15 @@ def _class_leaf_viz(node: ShadowDecTreeNode,
     # when using another dataset than the training dataset, some leaves could have 0 samples.
     # Trying to make a pie chart will raise some deprecation
     if sum(counts) == 0:
-        return
+        return False
     if leaftype == 'pie':
         _draw_piechart(counts, size=size, colors=colors, filename=filename, label=f"n={nsamples}\n{prediction}",
                       graph_colors=graph_colors, fontname=fontname)
+        return True
     elif leaftype == 'barh':
         _draw_barh_chart(counts, size=size, colors=colors, filename=filename, label=f"n={nsamples}\n{prediction}",
                       graph_colors=graph_colors, fontname=fontname)
+        return True
     else:
         raise ValueError(f'Undefined leaftype = {leaftype}')
 


### PR DESCRIPTION
Fixes the bug of graphviz erroring out due to file not found
Mentioned in that issue:
https://github.com/parrt/dtreeviz/issues/298

Code to reproduce:
```python
import sys
import pandas as pd
import numpy as np

import dtreeviz
import graphviz

from sklearn.model_selection import train_test_split

import xgboost as xgb

np.random.seed(42)

dataset_url = "https://raw.githubusercontent.com/parrt/dtreeviz/master/data/titanic/titanic.csv"
data = pd.read_csv(dataset_url, index_col=0)

data['Age'] = data['Age'].fillna(data['Age'].median())

cat_features = ['Sex', 'Embarked']

X, y = data[['Pclass', 'Sex', 'Age', 'SibSp', 'Parch', 'Fare', 'Embarked']], data['Survived']

X = pd.get_dummies(X, columns=cat_features)

X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42, shuffle=True)

params = {'max_depth':10, 'eta':0.05, 'objective':'binary:logistic', 'subsample':1}
model_xgb = xgb.XGBClassifier(**params, random_state=42)

model_xgb.fit(X_train, y_train)

# would work fine
viz_model = dtreeviz.model(
    model_xgb, tree_index=5,
    X_train=X_train, y_train=y_train,
    feature_names=list(X_train.columns),
    target_name='Survived', class_names=['perish', 'survive']
)

viz_model.view(fancy=False)

X_sample = X_test.sample(5)
y_sample = y_test.loc[X_sample.index]

viz_model = dtreeviz.model(
    model_xgb, tree_index=4,
    X_train=X_sample, y_train=y_sample,
    feature_names=list(X_sample.columns),
    target_name='Survived', class_names=['perish', 'survive']
)

# would fail due to file not found
viz_model.view(fancy=False)

```

Error message:
```
CalledProcessError: Command '['dot', '-Tsvg', '-o', '/tmp/DTreeViz_720.svg', '/tmp/DTreeViz_720']' returned non-zero exit status 1. [stderr: b'Warning: No such file or directory while opening /tmp/leaf33_720.svg\nError: No or improper image file="/tmp/leaf33_720.svg"\nin label of node leaf33\nWarning: No such file or directory while opening /tmp/leaf23_720.svg\nError: No or improper image file="/tmp/leaf23_720.svg"\nin label of node leaf23\nWarning: No such file or directory while opening /tmp/leaf39_720.svg\nError: No or improper image file="/tmp/leaf39_720.svg"\nin label of node leaf39\nWarning: No such file or directory while opening /tmp/leaf49_720.svg\nError: No or improper image file="/tmp/leaf49_720.svg"\nin label of node leaf49\nWarning: No such file or directory while opening /tmp/leaf42_720.svg\nError: No or improper image file="/tmp/leaf42_720.svg"\nin label of node leaf42\nWarning: No such file or directory while opening /tmp/leaf43_720.svg\nError: No or improper image file="/tmp/leaf43_720.svg"\nin label of node leaf43\nWarning: No such file or directory while opening /tmp/leaf53_720.svg\nError: No or improper image file="/tmp/leaf53_720.svg"\nin label of node leaf53\nWarning: No such file or directory while opening /tmp/leaf46_720.svg\nError: No or improper image file="/tmp/leaf46_720.svg"\nin label of node leaf46\n']
```

Colab example of failing: https://colab.research.google.com/drive/1TTX4m7H-S1y5BMqKy_YcWzmlaqJjYkn9?usp=sharing

Colab example of working after the fix: https://colab.research.google.com/drive/1xxPYYAKNwvkcF4Yj6cLK6fUJGxz-W0j6?usp=sharing

Rendered tree after fix:
<img width="974" alt="Screenshot 2023-06-06 at 19 17 40" src="https://github.com/parrt/dtreeviz/assets/44279105/bcd9dfcf-2c6d-4427-ade5-01adbcbf99b5">


_It might be worth adding some kind of a warning message, but I couldn't find anything like that across the package, so decided not to add it myself._ 