### PR TITLE
create a new "dev" extra, move pytest there

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ Finally, don't use IE to view .svg files. Use Edge as they look much better. I s
 
 Make sure to follow the install guidelines above.
 
+In order to run tests, you need to install the library with the `[develop]` extra:
+```bash 
+pip install dtreeviz[develop]        # Install develop dependencies
+```
+
 To push the `dtreeviz` library to your local egg cache (force updates) during development, do this (from anaconda prompt on Windows):
  
 ```bash 

--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ Finally, don't use IE to view .svg files. Use Edge as they look much better. I s
 
 Make sure to follow the install guidelines above.
 
-In order to run tests, you need to install the library with the `[develop]` extra:
+In order to run tests, you need to install the library with the `[dev]` extra:
 ```bash 
-pip install dtreeviz[develop]        # Install develop dependencies
+pip install dtreeviz[dev]        # Install develop dependencies
 ```
 
 To push the `dtreeviz` library to your local egg cache (force updates) during development, do this (from anaconda prompt on Windows):

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(
         'numpy',
         'scikit-learn',
         'matplotlib',
-        'colour',
-        'pytest'
+        'colour'
     ],
     extras_require={
         'xgboost': extra_xgboost,
@@ -33,6 +32,7 @@ setup(
         'lightgbm': extra_lightgbm,
         'tensorflow_decision_forests': extra_tensorflow,
         'all': extra_xgboost + extra_pyspark + extra_lightgbm + extra_tensorflow,
+        'develop': ['pytest']
     },
     python_requires='>=3.6',
     author='Terence Parr, Tudor Lapusan, and Prince Grover',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'lightgbm': extra_lightgbm,
         'tensorflow_decision_forests': extra_tensorflow,
         'all': extra_xgboost + extra_pyspark + extra_lightgbm + extra_tensorflow,
-        'develop': ['pytest']
+        'dev': ['pytest']
     },
     python_requires='>=3.6',
     author='Terence Parr, Tudor Lapusan, and Prince Grover',


### PR DESCRIPTION
Fixes #314 by:
- Introducing a new `develop` extra
- Moving `pytest` (not required at runtime) to this new extra
- Adding a small paragraph in the `README.md` under `## Install dtreeviz locally` as it already contains advice for development workflows

Please feel free to give me any feedback on the changes if there is a better way to address this issue